### PR TITLE
refactor: 검색어 변수 viewmodel에서 관리하도록 수정

### DIFF
--- a/app/src/main/java/com/nakyung/assignment_nakyung/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/nakyung/assignment_nakyung/ui/search/SearchScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,26 +37,30 @@ fun SearchRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val resultList = viewModel.pagingData.collectAsLazyPagingItems()
+    val keyword by viewModel.keyword.collectAsStateWithLifecycle()
 
     HandleSearchUi(
         modifier = modifier,
+        keyword = keyword,
         searchRepo = viewModel::getSearchResult,
         uiState = uiState,
         resultList = resultList,
         navigateToDetail = navigateToDetail,
+        updateKeyword = viewModel::updateKeyword,
     )
 }
 
 @Composable
 fun HandleSearchUi(
     modifier: Modifier,
+    keyword: String,
+    updateKeyword: (String) -> Unit,
     searchRepo: (String) -> Unit,
     uiState: SearchUiState,
     resultList: LazyPagingItems<Item>,
     navigateToDetail: (String, String) -> Unit,
 ) {
     val colors = MaterialTheme.colorScheme
-    var keyword by remember { mutableStateOf("") }
 
     Column(
         modifier =
@@ -68,7 +70,9 @@ fun HandleSearchUi(
     ) {
         SearchBar(
             keyword = keyword,
-            onKeywordChanged = { keyword = it },
+            onKeywordChanged = {
+                updateKeyword(it)
+            },
             onSearchClick = {
                 searchRepo(keyword)
             },

--- a/app/src/main/java/com/nakyung/assignment_nakyung/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/nakyung/assignment_nakyung/ui/search/SearchViewModel.kt
@@ -29,6 +29,13 @@ class SearchViewModel
         private val _uiState = MutableStateFlow<SearchUiState>(SearchUiState.Init)
         val uiState = _uiState.asStateFlow()
 
+        var keyword = MutableStateFlow("")
+            private set
+
+        fun updateKeyword(newKeyword: String) {
+            keyword.value = newKeyword
+        }
+
         fun getSearchResult(keyword: String) {
             viewModelScope.launch {
                 searchRepo(keyword)


### PR DESCRIPTION
- 상세 페이지에 들어갔다 나오는 경우 키워드가 다시 빈 값이 되는 문제 발생
    - 검색어 변수를 viewModel에서 관리하여 해결